### PR TITLE
Fix routing in 'Get Involved' footer link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
                 <p>Made with ❤️ by the Vanilla OS Contributors.</p>
             </div>
             <div class="footer-area">
-                <p>Vanilla OS is a Free and Open Source project. <a href="{{ site.url }}/get-involved/">Learn here</a> how get involved.</p>
+                <p>Vanilla OS is a Free and Open Source project. <a href="{{ site.url }}/get-involved">Learn here</a> how get involved.</p>
                 <p>
                     <small>Every software and component is licensed under different Open Source licenses.</small>
                 </p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
             </li>
             <li>
                 <a href="{{ site.url }}/get-involved"
-                    {% if page.url contains '/get-involved/' %}class="active"{% endif %}>Get Involved</a>
+                    {% if page.url contains '/get-involved' %}class="active"{% endif %}>Get Involved</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
Hey, checking the site I found an quick issue with the routing on the _Get Involved_ footer link.
I hope to contribute more in the future as I learn more about the OS.

This is only a small contribution for humanity, but (it could be) the first contribution for me.