### PR TITLE
Fix GitHub Repo link in Translate page

### DIFF
--- a/translate.md
+++ b/translate.md
@@ -11,7 +11,7 @@ The following table lists the projects repositories that are available for trans
 | Project | Repository | Translations |
 | ------- | ---------- | ------------ |
 | <img src="/assets/images/icons/control-center.svg" height="16" /> Control Center | [GitHub](https://github.com/Vanilla-OS/vanilla-control-center) | [GitLocalize](https://gitlocalize.com/repo/8091) |
-| <img src="/assets/images/icons/first-setup.svg" height="16" /> First Setup | [GitHub](https://github.com/Vanilla-OS/vanilla-first-setup) | [GitLocalize](https://gitlocalize.com/repo/8092) |
+| <img src="/assets/images/icons/first-setup.svg" height="16" /> First Setup | [GitHub](https://github.com/Vanilla-OS/first-setup) | [GitLocalize](https://gitlocalize.com/repo/8092) |
 | <img src="/assets/images/icons/installer.svg" height="16" /> Installer | [GitHub](https://github.com/Vanilla-OS/vanilla-installer) | [GitLocalize](https://gitlocalize.com/repo/8114) |
 | <img src="/assets/images/icons/almost.png" height="16" /> Almost | [GitHub](https://github.com/Vanilla-OS/Almost) | Not available yet |
 | <img src="/assets/images/icons/apx.png" height="16" /> Apx | [GitHub](https://github.com/Vanilla-OS/Apx) | Not available yet |


### PR DESCRIPTION
Fixes GitHub repository link for the first setup in translate Vanilla OS page