### PR TITLE
Fix: close the mobile menu by clicking outside or pressing ESC key

### DIFF
--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -17,3 +17,10 @@ document.addEventListener("click", (event) => {
     closeMenu();
   }
 });
+
+document.addEventListener("keyup", (event) => {
+  const isEscKeyPressed = event.key === "Esc" || event.key === "Escape";
+  if (isEscKeyPressed) {
+    closeMenu();
+  }
+});

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -10,3 +10,10 @@ function closeMenu() {
 }
 
 menuTogglerElement.addEventListener("click", toggleMenu);
+
+document.addEventListener("click", (event) => {
+  const isMenuTogglerClicked = menuTogglerElement.contains(event.target);
+  if (!isMenuTogglerClicked) {
+    closeMenu();
+  }
+});

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,5 +1,8 @@
+const menuElement = document.querySelector(".topbar-navigation");
+const menuTogglerElement = document.querySelector(".topbar-navigation-toggler");
+
 function toggleMenu() {
-    document.querySelector(".topbar-navigation").classList.toggle("show");
+  menuElement.classList.toggle("show");
 }
 
-document.querySelector(".topbar-navigation-toggler").addEventListener("click", toggleMenu);
+menuTogglerElement.addEventListener("click", toggleMenu);

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -5,4 +5,8 @@ function toggleMenu() {
   menuElement.classList.toggle("show");
 }
 
+function closeMenu() {
+  menuElement.classList.remove("show");
+}
+
 menuTogglerElement.addEventListener("click", toggleMenu);


### PR DESCRIPTION
This PR aims to fix issue #8. 

**Changes proposed**

The menu can now be closed by clicking outside the toggler icon or pressing the ESC key.

**Demo Gif**

- Running on Microsoft Edge

![demo](https://user-images.githubusercontent.com/62032328/202579630-e0a28c99-507b-4937-a056-be2abc36a7db.gif)
