### PR TITLE
replace privacy policy url in community link with discord

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,7 @@
             <div class="footer-area">
                 <h3>Community</h3>
                 <ul>
-                    <li><a href="{{ site.url }}/privacy-policy">Our Community</a></li>
+                    <li><a href="https://discord.gg/3cD2Q7Ht3S">Our Community</a></li>
                     <li><a href="{{ site.url }}/code-of-conduct">Code of Conduct</a></li>
                     <li><a href="{{ site.url }}/get-involved">Get Involved</a></li>
                 </ul>


### PR DESCRIPTION
The "Our Community" link in the footer references the privacy policy change. This updates the ```href``` attribute to the discord url.