### PR TITLE
Fix URL to FAQ on the main page

### DIFF
--- a/index.md
+++ b/index.md
@@ -152,7 +152,7 @@ description: Vanilla OS is an Immutable Linux-based distribution which aims to p
                 {% endcapture %}
                 {% include accordion-item.html title=title text=answer %}
             </div>
-            <a href="/faq/" class="button button-secondary">
+            <a href="/faq" class="button button-secondary">
                 Learn More <span class="material-icons-outlined">chevron_right</span>
             </a>
         </div>


### PR DESCRIPTION
Strangly enough, the URL worked fine locally, but breaks on the actual server.