### PR TITLE
Changes the download button to a download button

### DIFF
--- a/index.md
+++ b/index.md
@@ -16,7 +16,7 @@ description: Vanilla OS is an Immutable Linux-based distribution which aims to p
                 Get Vanilla OS 22.10 <span class="material-icons-outlined"> file_download </span>
             </a>
             <a href="#">Release Notes</a> -->
-            <a href="https://github.com/Vanilla-OS/os/releases/latest" class="button button-large">
+            <a href="https://github.com/Vanilla-OS/os/releases/download/22.10-r3/VanillaOS-22.10-all.20230105.iso" class="button button-large">
                 Get Vanilla OS 22.10 <span class="material-icons-outlined"> file_download </span>
             </a>
             <span>


### PR DESCRIPTION
It changes the link for downloading to a real download button, not a redirect to the release page. This will make it easier for people who just want the ISO. Although makes it less convenient as you have to update the link for every release

https://github.com/Vanilla-OS/os/releases/download/22.10-r3/VanillaOS-22.10-all.20230105.iso