### PR TITLE
Add rel="me" attribute for Fosstodon Link Verification

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -44,7 +44,7 @@
                 <h3>Follow us</h3>
                 <ul>
                     <li><a href="https://discord.gg/3cD2Q7Ht3S">Discord</a></li>
-                    <li><a href="https://fosstodon.org/@vanillaos">Mastodon</a></li>
+                    <li><a href="https://fosstodon.org/@vanillaos" rel="me">Mastodon</a></li>
                     <li><a href="https://twitter.com/VanillaOSLinux">Twitter</a></li>
                     <li><a href="{{ site.url }}/feed.xml">RSS</a></li>
                 </ul>


### PR DESCRIPTION
## Changes

- Added `rel="me"` attribute for verifying Fosstodon (Mastodon) Link Verification.

**After this PR's merge follow the following steps from [here](https://docs.joinmastodon.org/user/profile/) @mirkobrombin.**

TLDR

> Make sure to save your profile after adding the rel-me link to your web page! The verification process is triggered when you save your profile, and may take some time before completing. If you have added the rel-me link and verification is not working, then try deleting the link, saving, re-adding the link, and saving again.