### PR TITLE
ahover color change to #fbbe4e in dark mode

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -24,7 +24,7 @@
     }
 
     a:hover {
-        color: #eee;
+        color: #fbbe4e;
     }
 
     .scroll .topbar {


### PR DESCRIPTION
Issue #54 

Changes the color of the elements of the top nav bar to #fbbe4e when hover

Before changes: 
![2023-02-14 14_32_00-Vanilla OS - Brave](https://user-images.githubusercontent.com/69891912/218692485-82b9ae85-0833-4cfc-a55d-a1c68d8ce35c.png)

After changes: 
![2023-02-14 14_46_57-Vanilla OS - Brave](https://user-images.githubusercontent.com/69891912/218692518-a0704bdc-7d25-487e-b6fc-f3554eed3413.png)

Why this color? Because the vanilla os logo has the same color. I picked the color using color picker :) 
![2023-02-14 14_51_47-Color Picker](https://user-images.githubusercontent.com/69891912/218693031-27aea570-85c7-4771-b311-8081b6e4d3ab.png)

If you like these changes you can merge :) Have a good day!