### PR TITLE
fix syntax highlighting in documentation code block

### DIFF
--- a/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
+++ b/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
@@ -41,7 +41,7 @@ The commands of apx are similar to those of APT, the package manager adopted by 
 
 Below is the list of supported commands:-
 
-```text
+```plaintext
 Usage:
   apx [command]
 

--- a/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
+++ b/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
@@ -41,7 +41,7 @@ The commands of apx are similar to those of APT, the package manager adopted by 
 
 Below is the list of supported commands:-
 
-```
+```text
 Usage:
   apx [command]
 

--- a/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
+++ b/_posts/2023-01-28-apx-the-unconventional-pkg-manager.md
@@ -41,8 +41,7 @@ The commands of apx are similar to those of APT, the package manager adopted by 
 
 Below is the list of supported commands:-
 
-```plaintext
-Usage:
+<pre><code class="language-plaintext">Usage:
   apx [command]
 
 Available Commands:
@@ -72,7 +71,7 @@ Flags:
   -h, --help          help for apx
   -n, --name string   Create or use a custom container with this name.
   -v, --version       version for apx
-```
+</code></pre>
 
 At any time, it is possible to open a shell on the container you want and operate as if you were in that specific distribution. For example, you can type the following command to enter the Fedora container:-
 


### PR DESCRIPTION
In the [Blog post about APX](https://vanillaos.org/2023/01/28/apx-the-unconventional-pkg-manager.html), the syntax highlighting in the documentation code block under *Apx commands* is faulty. The reason seems to be that Jykell thinks the code block is SQL.
Setting the code block language to `text` should fix this, as [this should disable highlighting](https://www.fabriziomusacchio.com/blog/2021-08-11-Syntax_Highlighting_in_Jekyll/).