### PR TITLE
Fix blockquote dark styling

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -161,6 +161,10 @@
     .mark:after {
       background-color: #6a5920;
     }
+
+    .article-wrapper blockquote {
+        background-color: #3c3c3c54;
+    }
     
     @media screen and (max-width: 1000px) {
         .topbar-navigation {


### PR DESCRIPTION
This PR fixes the styling of the blockquote on dark mode, example:

| Old|
| ----------- | 
|<img src="https://user-images.githubusercontent.com/95353984/219972872-7ccb53c3-1808-4738-ad4e-4faa3dbfeb74.png" width="500">|

| New |
| ----------- | 
| <img src="https://user-images.githubusercontent.com/95353984/219973413-a5bf8603-fb67-4700-8015-5a51cda3be76.png" width="500">|