### PR TITLE
Fix item hovering underline styling in dark mode & prevent the hero-scroll from being stylized with an underline

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -23,6 +23,11 @@
         color: #fff;
     }
 
+    a:not(.button):not(.logo):not(.hero-scroll):hover {
+        color: #FFF;
+        border-bottom: 1px solid #FFF;
+    }
+
     a:hover {
         color: #fbbe4e;
     }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -67,7 +67,7 @@ a {
     border-bottom: 1px dotted #282828;
 }
 
-a:not(.button):not(.logo):hover {
+a:not(.button):not(.logo):not(.hero-scroll):hover {
     color: #000;
     border-bottom: 1px solid #000;
 }


### PR DESCRIPTION
Hovering over any item with the 'a' class would result in it being wrongly styled under dark mode, This PR aims to fix that by replacing the hover color with #FFF, that looks like this:
| Old|
| ----------- | 
![old](https://user-images.githubusercontent.com/95353984/222925197-d5023372-8fb7-449c-98ce-b9146b2dd879.png) 

| New |
| ----------- | 
![new](https://user-images.githubusercontent.com/95353984/222925287-4b1d676b-d3e9-4571-abaf-9f551e6e3ae9.png)

and also removes the hero-scroll class from being styled with an underline, as seen here:
| Before|
| ----------- | 
![hover](https://user-images.githubusercontent.com/95353984/222925370-2c0e1d6f-676f-4b9b-a1f4-6e197f1d5569.png)

| After |
| ----------- | 
![after](https://user-images.githubusercontent.com/95353984/222925497-a2adbbe3-ef6d-42bd-b4be-a29aedd69163.png)
