### PR TITLE
Add support for Fediverse to teams.md

### DIFF
--- a/assets/js/contributors.js
+++ b/assets/js/contributors.js
@@ -14,6 +14,9 @@ function displayContributors(contributors) {
                 <a href="https://github.com/${contributor.github_username}">
                     <ion-icon name="logo-github"></ion-icon>
                 </a>
+                <a href="{contributor.fediverselink}">
+                    <ion-icon name="logo-fediverse"<ion-icon>
+                <a>
                 ${contributor.main_company ? '<a class="contributor-fab" href="https://fabricators.ltd"><img src="assets/images/fabricators-logo.png" alt="Works at fabricators.ltd" title="Works at fabricators.ltd"></a>' : ''}
             </div>
         `;


### PR DESCRIPTION
This is just what I know how to do right now; I'll need pointers for the rest. I also need to figure out how logos are handled.

The Fediverse logo should be https://commons.wikimedia.org/wiki/Category:Fediverse, not a Mastodon logo, imo. 

https://socialhub.activitypub.rocks/t/fediverse-logo-or-icon-proposal/1057/23