### PR TITLE
Dark mode carousel elements now use hue rotation instead of greyscale

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -81,7 +81,7 @@
 
     .logo-carousel .logo-carousel-item img,
     .media-carousel .media-carousel-item img {
-        filter: saturate(0) invert(1);
+        filter: hue-rotate(180deg) invert(1);
     }
 
     .footer-secondary {


### PR DESCRIPTION
This allows logos to look less dead on dark mode while still being readable due to the lighter colours

Before:
![image](https://user-images.githubusercontent.com/48618519/231556228-457b59e5-1b48-4ef4-a815-0b0932ff9585.png)

After:
![image](https://user-images.githubusercontent.com/48618519/231556038-757446d3-3b63-4bf2-9a98-4cf9fd9342e7.png)
