### PR TITLE
Make dark mode media logos greyscale to match light mode site

### DIFF
--- a/assets/css/dark.css
+++ b/assets/css/dark.css
@@ -80,8 +80,12 @@
     }
 
     .logo-carousel .logo-carousel-item img,
-    .media-carousel .media-carousel-item img {
+    .media-carousel {
         filter: hue-rotate(180deg) invert(1);
+    }
+    
+    .media-carousel-item img {
+        filter: saturate(0) invert(1);
     }
 
     .footer-secondary {


### PR DESCRIPTION
I somehow missed this in my last PR oops

Light mode site:
![image](https://user-images.githubusercontent.com/48618519/234362017-b12325d6-11dc-4027-8f23-8db2cda3f453.png)

Dark mode site (this PR):
![image](https://user-images.githubusercontent.com/48618519/234362210-9f4f9ade-4e6f-41e7-aa12-f61c54745891.png)

Dark mode site (current):
![image](https://user-images.githubusercontent.com/48618519/234361926-e9728153-9c0a-4a99-b8ed-13326d867a32.png)