### PR TITLE
Change footer z-index to not cut off the toast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -588,7 +588,7 @@ main {
 /* Footer */
 .footer {
     position: relative;
-    z-index: 1;
+    z-index: 0;
 }
 
 .footer-secondary {


### PR DESCRIPTION
This PR changes the z-index of the footer so that the toast doesn't get cut off, demonstration:

Current:
![Screenshot_20230528_233447](https://github.com/Vanilla-OS/website/assets/95353984/4a30a4ab-bc41-4679-a235-6e85adb6540e)

Changed:
![Screenshot_20230528_233620](https://github.com/Vanilla-OS/website/assets/95353984/48db4d52-96c9-4e2a-adb5-06dd1b77468f)

Closes #91 