### PR TITLE
fix: resolve the issue #91

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -588,7 +588,7 @@ main {
 /* Footer */
 .footer {
     position: relative;
-    z-index: 1;
+    z-index: 0;
 }
 
 .footer-secondary {


### PR DESCRIPTION
Announcement section was not visible when scrolling down, reason was relative position and z-index 1, by changing z-index to 0, the issue was resolved and the position was not affected