### PR TITLE
Update 2023-07-05-vanilla-os-orchid-devlog.md - Fix automated script 

### DIFF
--- a/_posts/2023-07-05-vanilla-os-orchid-devlog.md
+++ b/_posts/2023-07-05-vanilla-os-orchid-devlog.md
@@ -74,7 +74,7 @@ chmod +x "$HOME/.local/bin/apx2"
 mkdir -p "$HOME/.config/apx"
 echo '{
   "apxPath": "'"$HOME/.local/share/apx/"'",
-  "distroboxpath": "'"$HOME/$WORK_DIR/distrobox-folder/distrobox/"'",
+  "distroboxpath": "'"$WORK_DIR/distrobox-1.5.0.2/distrobox"'",
   "storageDriver": "btrfs"
 }' > "$HOME/.config/apx/apx.json"
 


### PR DESCRIPTION
Updated the distroboxpath variable to accurately point at the installed distrobox.

No longer assumes $WORK_DIR is in $HOME when it might not be.
Changes the wrong folder name "distrobox-folder" to "distrobox-1.5.0.2", the folder name given after download and extraction. 
Removed trailing backslash