### PR TITLE
fix: links in Drivers Utility (Translate page)

### DIFF
--- a/src/views/get-involved/Translate.vue
+++ b/src/views/get-involved/Translate.vue
@@ -69,14 +69,14 @@ export default defineComponent({
                             title: 'Source Code',
                             icon: 'code',
                             onClick: () => {
-                                window.location.href = 'https://hosted.weblate.org/projects/vanilla-os/vanilla-drivers-utility/';
+                                window.location.href = 'https://github.com/Vanilla-OS/vanilla-drivers-utility';
                             },
                         },
                         {
                             title: 'Translate',
                             icon: 'translate',
                             onClick: () => {
-                                window.location.href = 'https://github.com/Vanilla-OS/vanilla-drivers-utility';
+                                window.location.href = 'https://hosted.weblate.org/projects/vanilla-os/vanilla-drivers-utility/';
                             },
                         },
                     ],


### PR DESCRIPTION
'Source Code' button is pointing to Weblate, while 'Translate' button is pointing to GitHub.