### PR TITLE
fix: Added .html to the contact links so it shows the actual page

### DIFF
--- a/src/views/get-involved/Funding.vue
+++ b/src/views/get-involved/Funding.vue
@@ -7,7 +7,7 @@
         <div class="text text--rich">
             <p>* This platform optionally allows you to make your donation anonymous. If you choose to do so, we will not
                 receive your name or any other information about you.</p>
-            <p>Once you have made a donation, <a href="https://fabricators.ltd/en/contact" target="_blank">contact us</a> to
+            <p>Once you have made a donation, <a href="https://fabricators.ltd/en/contact.html" target="_blank">contact us</a> to
                 give you the role of sponsor on our Discord server.</p>
         </div>
     </div>
@@ -84,7 +84,7 @@ BIC/SWIFT: SELBIT2BXXX</code></pre>`,
                     ]
                 },
                 {
-                    to: "https://fabricators.ltd/en/contact",
+                    to: "https://fabricators.ltd/en/contact.html",
                     extLink: true,
                     type: 'clickable',
                     icon: 'handshake',


### PR DESCRIPTION
The https://fabricators.ltd/contact shows a 404 page, I've update the link so it goes where it should.