### PR TITLE
fix:[#133] Fixed "...to works with ABRoot" typo

### DIFF
--- a/src/views/Roadmap.vue
+++ b/src/views/Roadmap.vue
@@ -101,7 +101,7 @@ export default defineComponent({
                     name: 'PRIME Utility',
                     status: 'Ongoing',
                     date: 'No date yet',
-                    description: 'We are updating our PRIME utility to works with ABRoot.',
+                    description: 'We are updating our PRIME utility to work with ABRoot.',
                 },
                 {
                     name: 'Vanilla Tools',


### PR DESCRIPTION
Instead of "We are updating our PRIME utility to works with ABRoot" it should be "We are updating our PRIME utility to work with ABRoot".

Closes #133