### PR TITLE
cleanup: Made the NavBar blurred on WebKit

### DIFF
--- a/public/assets/css/components/navigationBar.css
+++ b/public/assets/css/components/navigationBar.css
@@ -29,6 +29,7 @@
     top: -1px;
     z-index: 2;
     backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
 }
 
 .navigationBar ul {


### PR DESCRIPTION
Till now, the Navigation Bar on WebKit the backdrop wasn't used like how it's on Firefox & Chrome. With adding `-webkit-backdrop-filter` it works just how it should, here is an example:

Before:
![image](https://github.com/Vanilla-OS/website/assets/110247388/a2422256-c171-4b59-b89e-da7900fa3cf2)
After:
![image](https://github.com/Vanilla-OS/website/assets/110247388/60e84223-2526-486e-ad72-b39e275c4d94)

