### PR TITLE
cleanup: make Table use 100% width on all screens

### DIFF
--- a/public/assets/css/components/table.css
+++ b/public/assets/css/components/table.css
@@ -7,6 +7,7 @@
 .table {
     overflow: auto;
     max-width: 100%;
+    min-width: 100%;
 }
 
 .table-row--actions {


### PR DESCRIPTION
### Changes
- The table now looks like this (takes up all the space available), ref: https://discord.com/channels/1023243680829681704/1023243681324617780/1173001694272032808

![image](https://github.com/Vanilla-OS/website/assets/110247388/665ca168-f436-4523-913a-a0ef6308e888)
