### PR TITLE
fix: Add blur in overlay and toolbox for webkit browsers

### DIFF
--- a/public/assets/css/components/overlay.css
+++ b/public/assets/css/components/overlay.css
@@ -10,5 +10,6 @@
     bottom: 0;
     right: 0;
     backdrop-filter: saturate(180%) blur(20px);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
     z-index: 2;
 }

--- a/public/assets/css/components/toolBox.css
+++ b/public/assets/css/components/toolBox.css
@@ -19,6 +19,7 @@
     justify-content: center;
     font-size: 19px;
     backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
     position: sticky;
     bottom: 0px;
     margin: 40px 0 0 0;


### PR DESCRIPTION
This PR adds the `-webkit-backdrop-filter` CSS tag for overlay and toolbox so Webkit-based browsers can properly display blur.