### PR TITLE
fix: Fade in left for circuit image

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -139,7 +139,7 @@
 
   <section class="hero hero--big" id="solid">
     <div class="hero-wrapper container">
-      <img class="hero-image onFocus" data-focus-class="fadeInRight" src="/assets/images/backgrounds/solid-circuit.svg"
+      <img class="hero-image onFocus" data-focus-class="fadeInLeft" src="/assets/images/backgrounds/solid-circuit.svg"
         alt="Solid as a rock." />
       <article class="hero-content">
         <header class="hero-heading">


### PR DESCRIPTION
It doesn't make sense to have an image at the left side and make it fade in from the right