### PR TITLE
cleanup(blog search input): add right marging so the placeholder isn't seen & cursor pointer

### DIFF
--- a/public/assets/css/components/searchBar.css
+++ b/public/assets/css/components/searchBar.css
@@ -67,6 +67,7 @@
 
 .searchBar-shortcut {
     display: flex;
+    color: var(--text-color-dimmed);
 }
 
 .searchBar-shortcut>.mdi+span {

--- a/public/assets/css/components/searchBar.css
+++ b/public/assets/css/components/searchBar.css
@@ -14,6 +14,7 @@
 
 .searchBar-input {
     border: 0;
+    margin-right: 1px;
     font-size: 19px;
     outline: none;
     background-color: transparent;
@@ -35,6 +36,7 @@
     max-width: 500px;
     align-items: center;
     justify-content: flex-start;
+    cursor: pointer;
     background: var(--searchBar-field-background-color);
     padding: 6px 10px;
     border-radius: 12px;


### PR DESCRIPTION
The "Search" place holder is slightly seen, by adding `1px` right margin will hide it, and won't affect the search popup.

Along side, now on hovering, the cursor is a pointer no matter where you hover, slightly better experience I would say

## Preview

Website: https://search.gabs.pages.dev/blog

### Video

<small>(0:00 -> 0:01 is before, the rest is after)</small>

https://github.com/Vanilla-OS/website/assets/110247388/da1b18f4-e129-4941-8efc-2b60f7a44a3a
