### PR TITLE
cleanup: add Fosstodon Verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <base href="/" target="_blank">
   <link rel="icon" href="/favicon.ico">
+  <link rel="me" href="https://fosstodon.org/@vanillaos">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="/assets/css/index.css">
   <title>Vanilla OS</title>
@@ -100,7 +101,7 @@
         <ul class="list">
           <li><a href="https://github.com/Vanilla-OS" target="_blank">Support</a></li>
           <li><a href="https://twitter.com/VanillaOSLinux" target="_blank">Twitter</a></li>
-          <li><a href="https://fosstodon.org/@vanillaos" target="_blank">Mastodon</a></li>
+          <li><a href="https://fosstodon.org/@vanillaos" target="_blank" rel="me">Mastodon</a></li>
           <li><a href="https://discord.gg/vanilla-os-1023243680829681704" target="_blank">Discord</a></li>
         </ul>
 


### PR DESCRIPTION
I added the head link in case the link doesn't work (https://joinmastodon.org/verification).

Other servers don't see it as verified:

![Screenshot 2024-07-11 at 22 59 16](https://github.com/user-attachments/assets/9e0246de-5965-471f-a53b-9fa8e1886bc8)
