### PR TITLE
feat: restyle the image showcase and other features

### DIFF
--- a/public/assets/css/components/imageSlider.css
+++ b/public/assets/css/components/imageSlider.css
@@ -1,34 +1,53 @@
 .imageSlider {
-    display: flex;
-    overflow-x: hidden;
-    align-items: stretch;
+  display: flex;
+  overflow-x: hidden;
+  align-items: stretch;
 }
 
 .imageSlider-item {
-    flex: 0 0 100%;
-    transition: transform 0.3s ease;
-    transform: translateX(100%);
-    visibility: hidden;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 100%;
+  flex: 0 0 100%;
+  transition: transform 0.3s ease;
+  transform: translateX(100%);
+  visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
 }
 
 .imageSlider-item img {
-    height: 100%;
-    object-fit: cover;
-    cursor: pointer;
+  cursor: pointer;
+  border-radius: 3px;
+  height: 100%;
+  object-fit: cover;
+}
+
+@media screen and (max-width: 1200px) {
+  .imageSlider-item img {
+    height: auto;
+    width: 100%;
+    object-fit: contain;
+  }
 }
 
 .imageSlider-item:first-of-type.active {
-    transform: translateX(-0%);
+  transform: translateX(-0%);
 }
 
 .imageSlider-nav {
-    display: flex;
-    gap: 10px;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 20px;
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  transform: translate(-50%, -50%);
+  width: 15%;
+}
+
+@media screen and (max-width: 1200px) {
+  .imageSlider-nav {
+    width: 100%;
+  }
 }

--- a/public/assets/css/components/topBar.css
+++ b/public/assets/css/components/topBar.css
@@ -166,7 +166,7 @@
         display: flex;
         flex-direction: column;
         padding: 30px 10px;
-        z-index: 999;
+        z-index: 998;
         border-radius: 12px;
         background-color: var(--body-bg-color);
         box-shadow: var(--base-shadow);

--- a/src/components/ImageShowcase.vue
+++ b/src/components/ImageShowcase.vue
@@ -1,7 +1,7 @@
 <template>
     <div v-if="isOpen" class="modal modal--large-height anim--fadeIn">
         <div class="overlay" @click="closeModal"></div>
-        <div class="modal-wrapper card card--no-padding">
+        <div class="modal-wrapper">
             <div class="imageSlider">
                 <div v-for="(image, index) in articleImages" :key="index" class="imageSlider-item" :style="{
                     transform: `translateX(${index === currentIndex ? -index * 100 : 0}%)`,
@@ -73,6 +73,15 @@ export default defineComponent({
                 this.currentIndex++;
             }
         },
+        handleKeyboardEvent(event: KeyboardEvent) {
+            if (event.key === 'ArrowLeft') {
+                this.prevImage();
+            } else if (event.key === 'ArrowRight') {
+                this.nextImage();
+            } else if (event.key === 'Escape') {
+                this.closeModal();
+            }
+        },
     },
     computed: {
         isPrevDisabled(): boolean {
@@ -81,6 +90,12 @@ export default defineComponent({
         isNextDisabled(): boolean {
             return this.currentIndex === this.articleImages.length - 1;
         },
+    },
+    mounted() {
+        window.addEventListener('keydown', this.handleKeyboardEvent);
+    },
+    beforeUnmount() {
+        window.removeEventListener('keydown', this.handleKeyboardEvent);
     },
 });
 </script>

--- a/src/components/ImageShowcase.vue
+++ b/src/components/ImageShowcase.vue
@@ -5,7 +5,7 @@
             <div class="imageSlider">
                 <div v-for="(image, index) in articleImages" :key="index" class="imageSlider-item" :style="{
                     transform: `translateX(${index === currentIndex ? -index * 100 : 0}%)`,
-                    visibility: index === currentIndex ? 'visible' : 'hidden'
+                    visibility: index === currentIndex ? 'visible' : 'hidden',
                 }">
                     <img :src="image" @click="navigate(index)" />
                 </div>
@@ -26,12 +26,11 @@
     </div>
 </template>
 
-
 <script lang="ts">
 import { defineComponent, watch } from "vue";
 
 export default defineComponent({
-    name: 'ImageShowcase',
+    name: "ImageShowcase",
     props: {
         isOpen: {
             type: Boolean,
@@ -49,6 +48,8 @@ export default defineComponent({
     data() {
         return {
             currentIndex: this.currentImageIndex,
+            touchStartX: 0,
+            touchMoveX: 0,
         };
     },
     watch: {
@@ -58,10 +59,10 @@ export default defineComponent({
     },
     methods: {
         closeModal() {
-            this.$emit('close');
+            this.$emit("close");
         },
         navigate(index: number) {
-            this.$emit('navigate', index);
+            this.$emit("navigate", index);
         },
         prevImage() {
             if (this.currentIndex > 0) {
@@ -74,12 +75,36 @@ export default defineComponent({
             }
         },
         handleKeyboardEvent(event: KeyboardEvent) {
-            if (event.key === 'ArrowLeft') {
+            if (event.key === "ArrowLeft") {
                 this.prevImage();
-            } else if (event.key === 'ArrowRight') {
+            } else if (event.key === "ArrowRight") {
                 this.nextImage();
-            } else if (event.key === 'Escape') {
+            } else if (event.key === "Escape") {
                 this.closeModal();
+            }
+        },
+        addSwipeListeners() {
+            window.addEventListener("touchstart", this.handleTouchStart);
+            window.addEventListener("touchmove", this.handleTouchMove);
+            window.addEventListener("touchend", this.handleTouchEnd);
+        },
+        removeSwipeListeners() {
+            window.removeEventListener("touchstart", this.handleTouchStart);
+            window.removeEventListener("touchmove", this.handleTouchMove);
+            window.removeEventListener("touchend", this.handleTouchEnd);
+        },
+        handleTouchStart(event: TouchEvent) {
+            this.touchStartX = event.touches[0].clientX;
+        },
+        handleTouchMove(event: TouchEvent) {
+            this.touchMoveX = event.touches[0].clientX;
+        },
+        handleTouchEnd() {
+            const touchDistance = this.touchMoveX - this.touchStartX;
+            if (touchDistance > 0) {
+                this.prevImage();
+            } else if (touchDistance < 0) {
+                this.nextImage();
             }
         },
     },
@@ -92,10 +117,12 @@ export default defineComponent({
         },
     },
     mounted() {
-        window.addEventListener('keydown', this.handleKeyboardEvent);
+        window.addEventListener("keydown", this.handleKeyboardEvent);
+        this.addSwipeListeners();
     },
     beforeUnmount() {
-        window.removeEventListener('keydown', this.handleKeyboardEvent);
+        window.removeEventListener("keydown", this.handleKeyboardEvent);
+        this.removeSwipeListeners();
     },
 });
 </script>


### PR DESCRIPTION
## Changes

- Remove the `card` classes
- Reposition the navigation to being in the center
- Add navigation with keyboard between images and exiting the showcase
- Fix `topbar-navigation` button overlapping the close button on screens smaller then `745px`

---

**Live Deployment**: https://blog-images-on-mobile.gabs.pages.dev/blog/article/2024-07-16/discover-vso-v2-managing-your-vanilla-os-installation-like-never-before (example post)