### PR TITLE
Seperate navigationBar into sections on the home page

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -29,7 +29,7 @@
   </section>
 
   <nav class="navigationBar" aria-label="go to sections">
-    <h2 class="text text--dimmed" aria-labelledby=""> Vanilla OS is</h2>
+    <h2 class="text text--dimmed" aria-labelledby=""> Vanilla OS for</h2>
     <ul>
       <li :class="{ 'active': activeSection === 'work' }">
         <button @click="scrollTo('#work')">Work</button>
@@ -43,6 +43,9 @@
       <li :class="{ 'active': activeSection === 'access' }">
         <button @click="scrollTo('#access')">Access</button>
       </li>
+    </ul>
+    <h2 class="text text--dimmed" aria-labelledby=""> Vanilla OS is</h2>
+    <ul>
       <li :class="{ 'active': activeSection === 'solid' }">
         <button @click="scrollTo('#solid')">Solid</button>
       </li>


### PR DESCRIPTION
When reading the main page, I found the top header to be somewhat confusingly written, as it states that "Vanilla OS is Work, Play...". This PR separates the top navigationBar element into two sections, where Work, Play, Develop and Access are now prefixed by "Vanilla OS _for_", whilst Solid and Versatile remain prefixed by "Vanilla OS _is_". Hopefully this makes it read more logically and make more linguistic sense.

Before:
![image](https://github.com/user-attachments/assets/df340c79-b78a-4fae-ac30-af1384696878)

After:
![image](https://github.com/user-attachments/assets/a8bddd3b-b559-429f-a1d0-c48c8fc4a842)
 
As an aside, I'm not sure if it makes more sense to split these into two different sections of the page with different navigation bar widgets. Hopefully this should at least provide a starting point.