### PR TITLE
cleanup: small icon tweaks

### DIFF
--- a/public/assets/css/common.css
+++ b/public/assets/css/common.css
@@ -68,3 +68,8 @@ textarea {
 .clickable {
     cursor: pointer;
 }
+
+.mdi {
+    user-select: none;
+    cursor: default;
+}


### PR DESCRIPTION
- Make icons not be user selectable
- Hovering over icons now shows the default cursor, not the text cursor

## Preview

https://github.com/user-attachments/assets/538b8833-cdc2-4e7c-9c05-9037e5d92e42

