### PR TITLE
fix: image showcase not being displayed at all

### DIFF
--- a/public/assets/css/components/imageSlider.css
+++ b/public/assets/css/components/imageSlider.css
@@ -18,8 +18,10 @@
 .imageSlider-item img {
   cursor: pointer;
   border-radius: 3px;
-  height: 100%;
-  object-fit: cover;
+  max-height: 100%;
+  height: 60vh;
+  width: 100vh;
+  object-fit: contain;
 }
 
 @media screen and (max-width: 1200px) {

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="page page--article">
+    <div class="page page--article" @click="handleClick">
         <div class="page-wrapper container">
             <div class="page-header">
                 <div class="page-nav" v-if="parentRoute?.name">
@@ -146,7 +146,7 @@ export default defineComponent({
             this.currentImageIndex = index;
         },
         extractArticleImages(content: string) {
-            const imgRegex = /<img[^>]+src="([^">]+)/g;
+            const imgRegex = /<img(?![^>]*class="[^"]*Bento-card-carousel-page-image[^"]*")[^>]+src="([^">]+)/g;
             const matches = [];
             let match;
             while ((match = imgRegex.exec(content))) {
@@ -156,7 +156,9 @@ export default defineComponent({
         },
         handleClick(event: MouseEvent) {
             const target = event.target as HTMLElement;
-            if (target.tagName === 'IMG') {
+            const image = target.closest('img');
+            
+            if (image) {
                 const src = target.getAttribute('src');
                 if (src) {
                     const index = this.articleImages.indexOf(src);


### PR DESCRIPTION
- Small tweaks to the CSS also were made so the images are displayed in a more appealing way
- A filter was added to the extraction of images function so the images inside the bento grid when clicked won't trigger the showcase

## Preview

https://github.com/user-attachments/assets/11feb682-684e-403f-9dce-81fcfb250a06

