### PR TITLE
fix[close #127]: add atom feed for blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 
 /public/articles/
 /public/articles.json
+/public/feed.xml
 
 # Editor directories and files
 .vscode/*

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,13 @@
         "express": "^4.19.2",
         "express-rate-limit": "^7.4.0",
         "js-yaml": "^4.1.0",
-        "marked": "^5.1.1",
+        "marked": "^5.1.2",
         "prettier": "^3.3.3",
         "sirv": "^2.0.4",
         "slugify": "^1.6.6",
         "vue": "^3.2.47",
-        "vue-router": "^4.1.6"
+        "vue-router": "^4.1.6",
+        "xmldom": "^0.6.0"
       },
       "devDependencies": {
         "@types/node": "^18.17.0",
@@ -2200,6 +2201,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
       "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -3779,6 +3781,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "express": "^4.19.2",
     "express-rate-limit": "^7.4.0",
     "js-yaml": "^4.1.0",
-    "marked": "^5.1.1",
+    "marked": "^5.1.2",
     "prettier": "^3.3.3",
     "sirv": "^2.0.4",
     "slugify": "^1.6.6",
     "vue": "^3.2.47",
-    "vue-router": "^4.1.6"
+    "vue-router": "^4.1.6",
+    "xmldom": "^0.6.0"
   },
   "devDependencies": {
     "@types/node": "^18.17.0",

--- a/scripts/generateArticlesJson.cjs
+++ b/scripts/generateArticlesJson.cjs
@@ -2,6 +2,8 @@ const fs = require("fs");
 const path = require("path");
 const glob = require("glob");
 const yaml = require("js-yaml");
+const { marked } = require("marked");
+const { DOMParser, XMLSerializer } = require("xmldom");
 
 function cleanArticlesDir(articlesDir) {
   console.log(`Cleaning articles directory: ${articlesDir}`);
@@ -48,17 +50,17 @@ function readArticles(articlesPath) {
 
     const individualOutputDir = path.join(
       __dirname,
-      `../public/articles/${date}`
+      `../public/articles/${date}`,
     );
     fs.mkdirSync(individualOutputDir, { recursive: true });
 
     const individualOutputFilePath = path.join(
       individualOutputDir,
-      `${slug}.json`
+      `${slug}.json`,
     );
     fs.writeFileSync(
       individualOutputFilePath,
-      JSON.stringify(articleData, null, 2)
+      JSON.stringify(articleData, null, 2),
     );
     console.log(`Generated JSON file for article: ${title}`);
   }
@@ -88,7 +90,7 @@ function parseArticleHeader(content) {
     return { ...header, content: articleContent };
   } catch (error) {
     console.log(
-      `Invalid YAML format in the article header. Error: ${error.message}`
+      `Invalid YAML format in the article header. Error: ${error.message}`,
     );
     return { title: "", description: "", date: "", keywords: [], content: "" };
   }
@@ -122,3 +124,82 @@ const outputFilePath = path.join(__dirname, "../public/articles.json");
 fs.writeFileSync(outputFilePath, JSON.stringify(articles, null, 2));
 
 console.log("Articles JSON files generated.");
+
+// Generate Atom XML file
+
+function generateAtomFeed(articles, marked) {
+  const doc = new DOMParser().parseFromString(
+    `<?xml version="1.0" encoding="utf-8"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>`,
+    "application/xml",
+  );
+
+  const feed = doc.documentElement;
+
+  const createAndAppendElement = (tagName, textContent) => {
+    const element = doc.createElement(tagName);
+    element.textContent = textContent;
+    feed.appendChild(element);
+  };
+
+  const createAndAppendLink = (rel, href) => {
+    const link = doc.createElement("link");
+    link.setAttribute("rel", rel);
+    link.setAttribute("href", href);
+    feed.appendChild(link);
+  };
+
+  createAndAppendElement("id", "https://vanillaos.org/blog/");
+  createAndAppendElement("title", "Vanilla OS Blog");
+  createAndAppendElement(
+    "subtitle",
+    "Check out what's happening in Vanilla OS world.",
+  );
+
+  createAndAppendLink("alternate", "https://vanillaos.org/blog/");
+  createAndAppendLink("self", "https://vanillaos.org/feed.xml");
+
+  createAndAppendElement(
+    "logo",
+    "https://vanillaos.org/assets/images/brand/vanillaos-logo-icon.png",
+  );
+  createAndAppendElement("icon", "https://vanillaos.org/assets/favicon.ico");
+  createAndAppendElement("updated", new Date().toISOString());
+
+  for (const article of articles) {
+    const entry = doc.createElement("entry");
+
+    const createAndAppendEntryElement = (tagName, textContent) => {
+      const element = doc.createElement(tagName);
+      element.textContent = textContent;
+      entry.appendChild(element);
+    };
+
+    createAndAppendEntryElement("title", article.title);
+
+    const entryLink = doc.createElement("link");
+    entryLink.setAttribute(
+      "href",
+      `https://vanillaos.org/blog/article/${article.date}/${article.slug}`,
+    );
+    entry.appendChild(entryLink);
+
+    createAndAppendEntryElement(
+      "id",
+      `https://vanillaos.org/blog/article/${article.date}/${article.slug}`,
+    );
+    createAndAppendEntryElement("updated", article.date);
+    createAndAppendEntryElement("summary", article.description);
+
+    const entryContent = doc.createElement("content");
+    entryContent.setAttribute("type", "html");
+    entryContent.textContent = marked(article.content, {
+      mangle: false,
+      headerIds: false,
+    });
+    entry.appendChild(entryContent);
+
+    feed.appendChild(entry);
+  }
+
+  return new XMLSerializer().serializeToString(doc);
+}

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -35,6 +35,7 @@
                     <li><router-link :to="{ name: 'community' }">Community</router-link></li>
                     <li><router-link :to="{ name: 'get-involved' }">Get Involved</router-link></li>
                     <li><router-link :to="{ name: 'code-of-conduct' }">Code of Conduct</router-link></li>
+                    <li><a href="/feed.xml">RSS/Atom Feed</a></li>
                     <li class="spacer"></li>
                     <li><b>Support</b></li>
                     <li><a href="//documentation.vanillaos.org/">Documentation</a></li>

--- a/src/views/Article.vue
+++ b/src/views/Article.vue
@@ -22,8 +22,12 @@
                     <h2>Subscribe to the Newsletter</h2>
                     <div class="btn btn--primary" @click="isNotMailNotChimpOpen = true">
                         <span class="mdi material-icons">email</span>
-                        <span>Subscribe Now</span>
+                        <span>Subscribe via Email</span>
                     </div>
+                    <a class="btn btn--primary" href="https://vanillaos.org/feed.xml">
+                        <span class="mdi material-icons">newspaper</span>
+                        <span>Subscribe via the RSS Feed</span>
+                    </a>
                 </div>
                 <div class="card-content">
                     <div class="flexList">
@@ -157,7 +161,7 @@ export default defineComponent({
         handleClick(event: MouseEvent) {
             const target = event.target as HTMLElement;
             const image = target.closest('img');
-            
+
             if (image) {
                 const src = target.getAttribute('src');
                 if (src) {

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -39,8 +39,12 @@
                     </div>
                     <div class="btn btn--primary" @click="isNotMailNotChimpOpen = true">
                         <span class="mdi material-icons">email</span>
-                        <span>Subscribe Now</span>
+                        <span>Subscribe via Email</span>
                     </div>
+                    <a class="btn btn--primary" href="https://vanillaos.org/feed.xml">
+                        <span class="mdi material-icons">newspaper</span>
+                        <span>Subscribe via the RSS Feed</span>
+                    </a>
                 </div>
             </div>
         </div>
@@ -69,7 +73,7 @@
         <notmail-not-chimp :is-open="isNotMailNotChimpOpen" @close="closeNotMailNotChimp" />
     </div>
 </template>
-  
+
 <script lang="ts">
 import { loadArticles } from '@/articlesLoader';
 import type { Article } from '@/articlesLoader';


### PR DESCRIPTION
## Technical Notes

- For the feed, Atom is used, since it's easier to generate and newer
- `marked` was necessary to turn the Markdown into HTML
- I tried to make the code as <abbr title="Don't Repeat Yourself">DRY</abbr> as possible

---

Closes #127 