### PR TITLE
cleanup: add missing rss button & add margin only to the first child

### DIFF
--- a/public/assets/css/components/card.css
+++ b/public/assets/css/components/card.css
@@ -254,7 +254,7 @@
     font-size: 38px;
 }
 
-.card.card--type-adv.card--type-adv--hz .card-header .btn {
+.card.card--type-adv.card--type-adv--hz .card-header .btn:first-child {
     margin-top: 30px;
 }
 

--- a/src/views/download/DownloadOrchidStable.vue
+++ b/src/views/download/DownloadOrchidStable.vue
@@ -59,8 +59,12 @@
                         <h2>Subscribe to the Newsletter</h2>
                         <div class="btn btn--primary" @click="isNotMailNotChimpOpen = true">
                             <span class="mdi material-icons">email</span>
-                            <span>Subscribe Now</span>
+                            <span>Subscribe Now via Email</span>
                         </div>
+                        <a class="btn btn--primary" href="//vanillaos.org/feed.xml">
+                            <span class="mdi material-icons">newspaper</span>
+                            <span>Subscribe via the RSS Feed</span>
+                        </a>
                     </div>
                     <div class="card-content">
                         <div class="flexList">


### PR DESCRIPTION
Till now, all buttons inside the card header were getting a top margin of 30px, but that adds a lot of space not necessary for other than the first button. So I've made the 30px top margin only be added to the first child button of the card's header.

## Preview

**Live Server**: https://vos-pr.gxbs.me/download/orchid/stable