### PR TITLE
feat: add custom behavior for load more button in updates page

### DIFF
--- a/src/views/Updates.vue
+++ b/src/views/Updates.vue
@@ -57,7 +57,9 @@
 
         <div class="spacer spacer--lg"></div>
         <center>
-            <button @click="loadMoreDays" class="btn btn--primary">Load More</button>
+            <button @click="handleLoadMoreDays" class="btn btn--primary">
+                {{ buttonText }}
+            </button>
         </center>
         <div class="spacer spacer--lg"></div>
         <div class="card card--hz card--type-adv card--type-adv--hz card--purple">
@@ -107,12 +109,26 @@ export default defineComponent({
             displayedDays: [] as Day[],
             loadIndex: 0,
             loadIncrement: 15,
+            buttonText: 'Load More',
         };
     },
     methods: {
         loadMoreDays() {
             this.loadIndex += this.loadIncrement;
             this.displayedDays = this.days.slice(0, this.loadIndex);
+        },
+        handleLoadMoreDays() {
+            const button = document.querySelector('.btn.btn--primary');
+            if (this.loadIndex >= this.days.length) {
+                this.buttonText = 'Nothing more found';
+                if (button) button.setAttribute('disabled', 'true');
+                setTimeout(() => {
+                    this.buttonText = 'Load More';
+                    if (button) button.removeAttribute('disabled');
+                }, 1000);
+            } else {
+                this.loadMoreDays();
+            }
         },
         formatDate(dateString: string): string {
             const [month, day, year] = dateString.split('-');


### PR DESCRIPTION
Now, when you click on the load more button, and there are no more updates to load, the button will show a message saying "Nothing more found" and get disabled, both for 1 second.

## Preview

**Live Deployment**: https://load-more.gabs.pages.dev/updates

### Video

**Before**:

https://github.com/user-attachments/assets/6bd194e8-0033-4488-aad0-40fa2a1043af

**After**:

https://github.com/user-attachments/assets/9f65b343-7ab5-4f3d-8159-59cafbf7d73e

