### PR TITLE
fix: resolve image flickering in the access section on mobile

### DIFF
--- a/public/assets/css/components/hero.css
+++ b/public/assets/css/components/hero.css
@@ -210,6 +210,11 @@
         max-width: 100%;
     }
 
+    /* Fix image flickering on mobile */
+    #access .hero-image { 
+        width: 900px;
+    }
+
     .hero.hero--bg-center .hero-wrapper {
         padding: 0;
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -130,7 +130,7 @@
 
   <section class="hero hero--big hero--bg-center hero--extra-margin" id="access">
     <article class="hero-wrapper container">
-      <img class="hero-image onFocus" data-focus-class="fadeInZoom" src="/assets/images/backgrounds/apps-overview.png"
+      <img class="hero-image onFocus" data-focus-class="fadeIn" src="/assets/images/backgrounds/apps-overview.png"
         alt="Access the largest set of applications." />
       <div class="hero-content">
         <header class="hero-heading">


### PR DESCRIPTION
This pull request fixes the bug causing flickering of the image on the homepage in the access section on mobile devices, as reported in issue #227.

It was also observed that, on smaller resolutions, the image in the access section was not being displayed.

## Current version
Below is the current version of the website showing the issue:

https://github.com/user-attachments/assets/532e4d13-56b2-4e42-8668-b17e7504184f

## Fixed version
This video demonstrates the fixed version:

https://github.com/user-attachments/assets/09b75200-e41d-4eb2-914d-c9ad0218a2ce

closes #227 