### PR TITLE
fix: replace 'portuguese' with 'brazilian' in a card of a Brazilian influencer on the Spread page

### DIFF
--- a/src/views/get-involved/Spread.vue
+++ b/src/views/get-involved/Spread.vue
@@ -308,7 +308,7 @@ export default defineComponent({
                     icon: 'smart_display',
                     iconPack: 'mdi',
                     title: 'Desse jeito vou precisar aprender Linux de novo - Diolinux',
-                    description: "The portuguese Linux influencer DioLinux talked about Vanilla OS 2 Orchid, the upcoming release of Vanilla OS.",
+                    description: "The Brazilian Linux influencer DioLinux talked about Vanilla OS 2 Orchid, the upcoming release of Vanilla OS.",
                     badges: [
                         {
                             text: 'Portuguese',
@@ -326,7 +326,7 @@ export default defineComponent({
                     icon: 'smart_display',
                     iconPack: 'mdi',
                     title: 'Consigo me ver usando isso! | Vanilla OS 22.10 Review - Diolinux',
-                    description: "The portuguese Linux influencer DioLinux reviewed Vanilla OS 22.10 and he liked it a lot.",
+                    description: "The Brazilian Linux influencer DioLinux reviewed Vanilla OS 22.10 and he liked it a lot.",
                     badges: [
                         {
                             text: 'Portuguese',


### PR DESCRIPTION
This pull request updates the text on the **Spread the Word** page by replacing the word "portuguese" with "Brazilian" in the cards dedicated to the Brazilian YouTuber Diolinux.

On the Spread the Word page, there are two cards featuring Diolinux (https://www.youtube.com/@Diolinux), but the text currently uses "Portuguese" to refer to his nationality. However, DioLinux is Brazilian.

## Current version

![portuguse_instead_of_brazilian](https://github.com/user-attachments/assets/c512746e-e131-4101-ad2f-be6d8606b188)

## Fixed version

![portuguese_instead_of_brazilian_fixed](https://github.com/user-attachments/assets/0bd156a1-570a-4e42-bc9f-323bb725bea4)