### PR TITLE
cleanup: migrate the center tag to an class

### DIFF
--- a/public/assets/css/components/text.css
+++ b/public/assets/css/components/text.css
@@ -152,3 +152,7 @@
 .text--rich.text--sm p {
     margin: 0 0 5px 0;
 }
+
+.text--center {
+    text-align: center;
+}

--- a/src/views/Updates.vue
+++ b/src/views/Updates.vue
@@ -56,11 +56,11 @@
         </div>
 
         <div class="spacer spacer--lg"></div>
-        <center>
+        <p class="text--center">
             <button @click="handleLoadMoreDays" class="btn btn--primary">
                 {{ buttonText }}
             </button>
-        </center>
+        </p>
         <div class="spacer spacer--lg"></div>
         <div class="card card--hz card--type-adv card--type-adv--hz card--purple">
             <div class="card-header">

--- a/src/views/download/DownloadOrchidStable.vue
+++ b/src/views/download/DownloadOrchidStable.vue
@@ -15,12 +15,9 @@
     <div class="container">
         <div class="flexList flexList--center">
             <div class="spacer"></div>
-            <div class="text text--rich">
-                <center>
+            <div class="text text--rich text--center">
                     <p>Vanilla OS 2 Orchid is the next generation of Vanilla OS. It is built on top of new technologies
-                        and
-                        features to provide you with the most secure, stable and stunning system experience.</p>
-                </center>
+                        and features to provide you with the most secure, stable and stunning system experience.</p>
             </div>
             <a href="https://download.vanillaos.org/latest.zip" class="btn btn--primary btn--big">
                 <span class="material-symbols-outlined">file_download</span>
@@ -40,12 +37,10 @@
                     </a>
                 </small>
             </div>
-            <div class="text text--rich">
-                <center>
+            <div class="text text--rich text--center">
                     <p>Do you enjoy Vanilla OS? Consider <router-link
                             to="/get-involved/funding">supporting</router-link>
                         the project.</p>
-                </center>
             </div>
             <div class="spacer"></div>
         </div>


### PR DESCRIPTION
Since the `<center>` tag is deprecated See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center