### PR TITLE
Replace "application" with "app"

### DIFF
--- a/src/components/BentoOrchidRelease.vue
+++ b/src/components/BentoOrchidRelease.vue
@@ -15,8 +15,8 @@
                 bgcolor="#FEEED1" image="/assets/images/3rd-party/logo-linux.svg" imageSize="40px"
                 imageLocation="right">
                 <template #title>Linux</template>
-                <template #content>Thanks to the APX utility you can install applications from every Linux distribution
-                    out there, whether they are CLI or GUI applications.</template>
+                <template #content>Thanks to the APX utility you can install apps from every Linux distribution
+                    out there, whether they are CLI or GUI apps.</template>
             </bento-card>
             <bento-card-carousel class="Bento-card Bento-card--4" :pages="pages" />
         </template>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -70,7 +70,7 @@
             <p>The desktop environment is perfect for your daily tasks, thanks to its clean and intuitive interface.
               Everything is setup so that you can start working, and focus on what matters.</p>
             <p>Vanilla OS is ready to meet your needs whether you are a developer, designer, or student, thanks to a wide
-              range of applications.</p>
+              range of apps.</p>
           </div>
         </div>
       </article>
@@ -131,11 +131,11 @@
   <section class="hero hero--big hero--bg-center hero--extra-margin" id="access">
     <article class="hero-wrapper container">
       <img class="hero-image onFocus" data-focus-class="fadeIn" src="/assets/images/backgrounds/apps-overview.png"
-        alt="Access the largest set of applications." />
+        alt="Access the largest set of apps." />
       <div class="hero-content">
         <header class="hero-heading">
           <h2 class="color--access-1">Access</h2>
-          <b class="color--access-2">the largest set of applications.</b>
+          <b class="color--access-2">the largest set of apps.</b>
         </header>
       </div>
     </article>

--- a/src/views/NerdInfo.vue
+++ b/src/views/NerdInfo.vue
@@ -105,11 +105,11 @@ export default defineComponent({
                 {
                     icon: 'android',
                     title: 'Android Compatibility',
-                    description: 'Vanilla OS is compatible with Android applications thanks to VSO, Waydroid, and F-Droid.\
+                    description: 'Vanilla OS is compatible with Android apps thanks to VSO, Waydroid, and F-Droid.\
                     VSO is the Vanilla System Operator, the point of contact between the system and the user.\
-                    It allows the user to manage the system in many ways, such as installing Android applications\
+                    It allows the user to manage the system in many ways, such as installing Android apps\
                     through our container-based Waydroid integration, and F-Droid, a free and open-source Android\
-                    application store.',
+                    app store.',
                 },
                 {
                     icon: 'key',

--- a/src/views/help/Faq.vue
+++ b/src/views/help/Faq.vue
@@ -37,7 +37,7 @@ export default defineComponent({
                     to: { name: 'help' },
                     icon: '',
                     title: 'How can I install software?',
-                    description: "Vanilla OS provides optional support for Flatpak, AppImage, and soon Snap. We recommend you use any of these three for regular application installation. We also have our own package manager, apx. You can use it from the terminal to install Ubuntu, Fedora, or Arch Linux packages inside containers.",
+                    description: "Vanilla OS provides optional support for Flatpak, AppImage, and soon Snap. We recommend you use any of these three for regular app installation. We also have our own package manager, apx. You can use it from the terminal to install Ubuntu, Fedora, or Arch Linux packages inside containers.",
                     extraClasses: ['flexGrid-item--4'],
                 },
                 {


### PR DESCRIPTION
The latter is preferred nowadays and widely used in the GNOME ecosystem.

(This PR does not replace the word in _articles/*_ because that would be too many changes, also I did not want to modify the already published posts.)